### PR TITLE
Update `gorm` dependency to v1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	google.golang.org/grpc v1.58.2
 	gorm.io/driver/mysql v1.5.2
 	gorm.io/driver/postgres v1.5.4
-	gorm.io/gorm v1.25.5
+	gorm.io/gorm v1.25.9
 )
 
 require (


### PR DESCRIPTION
I've had a case where I use a polymorphic relationship on my [Gorm](https://gorm.io/) model, where I use a custom field for the `id` and `type`. And the feature doesn't exist on the current version of gorm used in the framework ([v1.25.5](https://github.com/go-gorm/gorm/releases/tag/v1.25.5)). So, I decided to update the gorm version to ([v1.25.9](https://github.com/go-gorm/gorm/releases/tag/v1.25.9)). That's it. Thank You.

You can check the detailed of the pull request [here](https://github.com/go-gorm/gorm/pull/6716).